### PR TITLE
change location bedfiles are saved, keep root directory clean

### DIFF
--- a/output/25012024_101115panel_output.bed
+++ b/output/25012024_101115panel_output.bed
@@ -1,1 +1,0 @@
-chrom	chromStart	chromEnd	name	score	strand

--- a/output/25012024_101115panel_output.bed
+++ b/output/25012024_101115panel_output.bed
@@ -1,0 +1,1 @@
+chrom	chromStart	chromEnd	name	score	strand

--- a/output/25012024_101359/panel_output.bed
+++ b/output/25012024_101359/panel_output.bed
@@ -1,0 +1,1 @@
+chrom	chromStart	chromEnd	name	score	strand

--- a/src/functions.py
+++ b/src/functions.py
@@ -416,13 +416,18 @@ def call_transcript_make_bed(hgnc_list, flank, genome_build,
         mane, select
     """
 
+    # get date and time for savinf files
+    date_of_running = datetime.now()
+    dt_string = date_of_running.strftime("%d%m%Y_%H%M%S")
+
     # build the url for connecting to variant validator
     url_base = ("https://rest.variantvalidator.org/VariantValidator/tools/gene2transcripts_v2/HGNC%3A/") # TODO to long for PEP8 standards
     transcript_filter = "/" + limited_transcripts + "/" + transcript_set + "/" + genome_build # TODO to long for PEP8 standards
 
+    os.mkdir("output/" + dt_string)
     # make empty bed file
     print("Making bed file for gene list:" + str(hgnc_list))
-    concat_filename = "panel_output.bed"
+    concat_filename = "output/" + dt_string + "/panel_output.bed"
     with open(concat_filename, 'w') as f:
         f.write("chrom\tchromStart\tchromEnd\tname\tscore\tstrand\n")
 
@@ -511,7 +516,7 @@ def call_transcript_make_bed(hgnc_list, flank, genome_build,
         # make bedfile header
         print("Making bed file for HGNC:" + str(hgnc))
         filename = str(hgnc) + "_output.bed"
-        with open(filename, 'w') as f:
+        with open("output/" + dt_string + "/" + filename, 'w') as f:
             f.write("chromosome\tstart\tend\tname\tscore\tstrand\n")
 
         # build bed file


### PR DESCRIPTION
- Update bedfile making to save bedfiles in a location that is no the root directory
- bed files now saved in output folder, with sub folders created based on the date and time of the run